### PR TITLE
strip leading directory seperators for readme aswell as nuspec icon p…

### DIFF
--- a/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -29,7 +29,10 @@ namespace BaGet.Core
                 throw new InvalidOperationException("Package does not have a readme!");
             }
 
-            return await package.GetStreamAsync(readmePath, cancellationToken);
+            return await package.GetStreamAsync(
+                PathUtility.StripLeadingDirectorySeparators(
+                    PathUtility.GetPathWithBackSlashes(readmePath)), 
+                cancellationToken);
         }
 
         public async static Task<Stream> GetIconAsync(
@@ -37,7 +40,8 @@ namespace BaGet.Core
             CancellationToken cancellationToken)
         {
             return await package.GetStreamAsync(
-                PathUtility.StripLeadingDirectorySeparators(package.NuspecReader.GetIcon()),
+                PathUtility.StripLeadingDirectorySeparators(
+                    PathUtility.GetPathWithBackSlashes(package.NuspecReader.GetIcon())), 
                 cancellationToken);
         }
 


### PR DESCRIPTION
…ath - always use forward slashes as this works on windows and linux

Summary of the changes (in less than 80 chars)

 * Detail 1
 * Detail 2

Addresses https://github.com/loic-sharma/BaGet/issues/123
