### PR TITLE
using StripLeadingDirectorySeparators on readmePath

### DIFF
--- a/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -29,7 +29,9 @@ namespace BaGet.Core
                 throw new InvalidOperationException("Package does not have a readme!");
             }
 
-            return await package.GetStreamAsync(readmePath, cancellationToken);
+            return await package.GetStreamAsync(
+                PathUtility.StripLeadingDirectorySeparators(readmePath), 
+                cancellationToken);
         }
 
         public async static Task<Stream> GetIconAsync(


### PR DESCRIPTION
as already done on iconPath - this fixes issues with backslash on linux aswell.

Summary of the changes (in less than 80 chars)

    fix issue with docs\README.md path on linux
    same threatment as iconPath has already received

Addresses https://github.com/loic-sharma/BaGet/issues/513